### PR TITLE
JSON Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-if: tag IS present # If you need to run tests etc. on each commit, remove this.
 before_install:
 - sudo apt-get install -y p7zip-full
 - bash travis_install_swift.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 if: tag IS present # If you need to run tests etc. on each commit, remove this.
 before_install:
 - sudo apt-get install -y p7zip-full
+- bash travis_install_swift.sh
 language: python
 python:
 - '3.6'
 script:
 - python travis_build_script.py
+- bash travis_validate_json.sh
 deploy:
   provider: releases
   api_key:

--- a/JSONValidator/.gitignore
+++ b/JSONValidator/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/JSONValidator/Package.swift
+++ b/JSONValidator/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:4.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+	name: "JSONValidator",
+	products: [
+		// Products define the executables and libraries produced by a package, and make them visible to other packages.
+		.library(
+			name: "JSONValidator",
+			targets: ["JSONValidator"]
+		),
+	],
+	dependencies: [
+		// Dependencies declare other packages that this package depends on.
+		// .package(url: /* package url */, from: "1.0.0"),
+		.package(url: "https://github.com/tellowkrinkle/PedanticJSONDecoder.git", from: "1.1.0")
+	],
+	targets: [
+		// Targets are the basic building blocks of a package. A target can define a module or a test suite.
+		// Targets can depend on other targets in this package, and on products in packages which this package depends on.
+		.target(
+			name: "JSONValidator",
+			dependencies: []
+		),
+		.testTarget(
+			name: "JSONValidatorTests",
+			dependencies: ["JSONValidator", "PedanticJSONDecoder"]
+		),
+	]
+)

--- a/JSONValidator/README.md
+++ b/JSONValidator/README.md
@@ -1,0 +1,3 @@
+# JSONValidator
+
+Validates the JSON in `installData.json` to make sure it matches the spec in `JSONValidator.swift` and all the URLs are valid.

--- a/JSONValidator/Sources/JSONValidator/JSONValidator.swift
+++ b/JSONValidator/Sources/JSONValidator/JSONValidator.swift
@@ -1,15 +1,37 @@
+/*
+Reading this file (for those not familiar with swift)
+
+Each struct represents one object in JSON.
+Each variable name (prefixed with `public var`) is a key in the JSON object, and the thing to the right of the colon is its type.
+Types surrounded by `[]`s are arrays of that type, so `[String]` would be an array of strings.
+Types with a `?` after them are optional, meaning they can be null (or completely missing from the JSON).
+
+An enum represents a fixed set of strings (for example, the enum `OS` indicates a value that can be either the string "mac", "linux", or "windows" but nothing else)
+*/
+
+/// The top level object in `installData.json`
 public struct InstallDataDefinition: Codable {
 	/// Increment this every time a breaking change is made to the installData JSON that would cause earlier versions of the installer to misparse it.
 	public var version: Int
 	public var mods: [ModDefinition]
 }
 
+/// Represents one mod for a game
+///
+/// The difference between a mod and a submod is that a user might be expected to have one of each mod installed, but would not be expected to have more than one submod of that mod.
+/// Based on that, Himatsubushi and Console Arcs are separate mods (even though they're based on the same game), but a voice only patch and full version would be submods
 public struct ModDefinition: Codable {
+	/// Used to decide how the installer should run, since higurashi and umineko games have very different layouts
 	public var family: ModFamily
+	/// The name of the mod (will be displayed to the user)
 	public var name: String
+	/// The name of the game this mod installs onto
 	public var target: String
+	/// The name of the folder that contains the game data (e.g. HigurashiEp02_Data)
 	public var dataname: String
+	/// Filenames that, if found in a folder, indicate that it is the game data folder of this mod's target
 	public var identifiers: [String]
+	/// The list of submods this mod has
 	public var submods: [SubmodDefinition]
 	/// If this exists and the user is on macOS, the installer will overwrite the CFBundleName of the target application with the name given here.  This will change the name that shows up when the application is launched.
 	public var CFBundleName: String?
@@ -24,20 +46,32 @@ public enum ModFamily: String, Codable {
 
 public struct SubmodDefinition: Codable {
 	public var name: String
+	/// The base set of files for this mod
 	public var files: [FileDefinition]
+	/// Platform-specific overrides of files in `files`
 	public var fileOverrides: [FileOverrideDefinition]
 }
 
 public struct FileDefinition: Codable {
+	/// A name to identify this file for use in overrides
 	public var name: String
+	/// The url for this file
 	public var url: String
+	/// The priority of this file.  Higher priority files are installed later so they will overwrite lower priority files
 	public var priority: Int
 }
 
 public struct FileOverrideDefinition: Codable {
+	/// This override will replace a file with the same name
+	/// - warning: It is an error to specify a name that is not in the `files` of the submod
 	public var name: String
+	/// The OSes this override should be applied on
 	public var os: [OS]
+	/// - If true, this override will only be applied if the game is a steam version.
+	/// - If false, this override will only be applied if the game is not a steam version.
+	/// - If null, this override will be applied regardless of whether the game is a steam version.
 	public var steam: Bool?
+	/// The url for this file override
 	public var url: String
 }
 

--- a/JSONValidator/Sources/JSONValidator/JSONValidator.swift
+++ b/JSONValidator/Sources/JSONValidator/JSONValidator.swift
@@ -1,0 +1,48 @@
+public struct InstallDataDefinition: Codable {
+	/// Increment this every time a breaking change is made to the installData JSON that would cause earlier versions of the installer to misparse it.
+	public var version: Int
+	public var mods: [ModDefinition]
+}
+
+public struct ModDefinition: Codable {
+	public var family: ModFamily
+	public var name: String
+	public var target: String
+	public var dataname: String
+	public var identifiers: [String]
+	public var submods: [SubmodDefinition]
+	/// If this exists and the user is on macOS, the installer will overwrite the CFBundleName of the target application with the name given here.  This will change the name that shows up when the application is launched.
+	public var CFBundleName: String?
+	/// If this exists and the user is on macOS, the installer will overwrite the CFBundleIdentifier of the target application with the name given here.  This will change the save directory used on Higurashi games.
+	public var CFBundleIdentifier: String?
+}
+
+public enum ModFamily: String, Codable {
+	case higurashi
+	case umineko
+}
+
+public struct SubmodDefinition: Codable {
+	public var name: String
+	public var files: [FileDefinition]
+	public var fileOverrides: [FileOverrideDefinition]
+}
+
+public struct FileDefinition: Codable {
+	public var name: String
+	public var url: String
+	public var priority: Int
+}
+
+public struct FileOverrideDefinition: Codable {
+	public var name: String
+	public var os: [OS]
+	public var steam: Bool?
+	public var url: String
+}
+
+public enum OS: String, Codable {
+	case mac
+	case linux
+	case windows
+}

--- a/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
+++ b/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import PedanticJSONDecoder
+@testable import JSONValidator
+
+let rootDirectory = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+let installData = rootDirectory.appendingPathComponent("installData.json", isDirectory: false)
+
+extension Array where Element == CodingKey {
+	var stringValue: String {
+		return map({ $0.stringValue }).joined(separator: " → ")
+	}
+
+	var pathString: String {
+		let str = stringValue
+		return str.isEmpty ? "top level" : "path \(str)"
+	}
+}
+
+final class JSONValidatorTests: XCTestCase {
+	func testFindInstallData() {
+		XCTAssertNoThrow(try Data(contentsOf: installData))
+	}
+
+	func testValidateJSON() {
+		let decoder = PedanticJSONDecoder()
+		do {
+			_ = try decoder.decode(InstallDataDefinition.self, from: try Data(contentsOf: installData))
+		}
+		catch let error as PedanticJSONDecoder.IgnoredKeysError {
+			let message = error.keysets.map({ keyset -> String in
+				return "The keys \(keyset.ignoredKeys) were in installData.json at the \(keyset.path.pathString), but nothing should be there according to the spec in JSONValidator.swift"
+			}).joined(separator: "\n")
+			XCTFail(message)
+		}
+		catch let error as DecodingError {
+			switch error {
+			case .dataCorrupted(let context):
+				XCTFail("Something went wrong decoding installData.json at the \(context.codingPath.pathString): \(context.debugDescription)")
+			case .keyNotFound(let key, let context):
+				XCTFail("According to the spec in JSONValidator.swift, a \"\(key.stringValue)\" key should have been at the \(context.codingPath.pathString) in installData.json, but there wasn't anything there")
+			case .valueNotFound(let expectedType, let context):
+				XCTFail("According to the spec in JSONValidator.swift, there should have been a \(expectedType) at the \(context.codingPath.pathString), but in installData.json, the value was null instead")
+			case .typeMismatch(let expectedType, let context):
+				XCTFail("According to the spec in JSONValidator.swift, there should have been a \(expectedType) at the \(context.codingPath.pathString), but the value in installData.json couldn't be converted to that: \(context.debugDescription)")
+			}
+		}
+		catch {
+			// Force an assertion failure with the error
+			XCTAssertNoThrow(try { throw error }())
+		}
+	}
+
+	func testURLsExist() {
+		let decoder = PedanticJSONDecoder()
+		guard let installData = try? decoder.decode(InstallDataDefinition.self, from: Data(contentsOf: installData)) else {
+			XCTFail("Failed to decode install data, look at other tests for details")
+			return
+		}
+		let allURLs = installData.mods.flatMap({ mod -> [String] in
+			return mod.submods.flatMap { submod -> [String] in
+				return submod.files.map { $0.url } + submod.fileOverrides.map { $0.url }
+			}
+		}).compactMap { urlString -> URL? in
+			let url = URL(string: urlString)
+			XCTAssertNotNil(url, "The url \"\(urlString)\" was invalid")
+			return url
+		}
+		let expecations = allURLs.map { url -> XCTestExpectation in
+			let e = expectation(description: "\(url) should be retrievable")
+			let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
+			var request = URLRequest(url: url)
+			request.setValue("bytes=0-1023", forHTTPHeaderField: "Range")
+
+			var task: URLSessionDataTask? = nil
+			task = session.dataTask(with: request) { [weak task] (data, response, error) in
+				task?.cancel()
+				e.fulfill()
+				if let error = error {
+					XCTFail("Failed to download \(url): \(error)")
+				}
+				else if let response = response as? HTTPURLResponse {
+					if response.statusCode != 200 && response.statusCode != 206 {
+						XCTFail("Failed to download \(url): response code was \(response.statusCode)")
+					}
+				}
+				else if let response = response {
+					XCTFail("Failed to download \(url): unexpected response: \(response)")
+				}
+				else {
+					XCTFail("Failed to download \(url): got nil response with no error")
+				}
+			}
+			task!.resume()
+			return e
+		}
+		wait(for: expecations, timeout: 10)
+	}
+
+	static var allTests = [
+		("Finds installData.json", testFindInstallData),
+		("Validate JSON", testValidateJSON),
+		("Ensure that all URLs actually exist", testURLsExist)
+	]
+}

--- a/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
+++ b/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
@@ -50,6 +50,23 @@ final class JSONValidatorTests: XCTestCase {
 		}
 	}
 
+	func testOverridesAreValid() {
+		let decoder = PedanticJSONDecoder()
+		guard let installData = try? decoder.decode(InstallDataDefinition.self, from: Data(contentsOf: installData)) else {
+			XCTFail("Failed to decode install data, look at other tests for details")
+			return
+		}
+		for mod in installData.mods {
+			for submod in mod.submods {
+				let files = Set(submod.files.lazy.map { $0.name })
+				XCTAssertEqual(files.count, submod.files.count, "Multiple files were specified with the same name in \(mod.name) \(submod.name)")
+				for override in submod.fileOverrides {
+					XCTAssert(files.contains(override.name), "Override \(override.name) must override a file in the file list of \(mod.name) \(submod.name)")
+				}
+			}
+		}
+	}
+
 	func testURLsExist() {
 		let decoder = PedanticJSONDecoder()
 		guard let installData = try? decoder.decode(InstallDataDefinition.self, from: Data(contentsOf: installData)) else {
@@ -97,6 +114,7 @@ final class JSONValidatorTests: XCTestCase {
 	static var allTests = [
 		("Finds installData.json", testFindInstallData),
 		("Validate JSON", testValidateJSON),
-		("Ensure that all URLs actually exist", testURLsExist)
+		("Ensure all file overrides override something", testOverridesAreValid),
+		("Ensure that all URLs actually exist", testURLsExist),
 	]
 }

--- a/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
+++ b/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
@@ -65,16 +65,14 @@ final class JSONValidatorTests: XCTestCase {
 			XCTAssertNotNil(url, "The url \"\(urlString)\" was invalid")
 			return url
 		}
-		let expecations = Set(allURLs).map { url -> XCTestExpectation in
+		for url in Set(allURLs) {
 			let e = expectation(description: "\(url) should be retrievable")
-			let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
 			var request = URLRequest(url: url)
 			request.setValue("bytes=0-1023", forHTTPHeaderField: "Range")
 
 			var task: URLSessionDataTask? = nil
-			task = session.dataTask(with: request) { [weak task] (data, response, error) in
+			task = URLSession.shared.dataTask(with: request) { [weak task] (data, response, error) in
 				task?.cancel()
-				e.fulfill()
 				if let error = error {
 					XCTFail("Failed to download \(url): \(error)")
 				}
@@ -89,11 +87,11 @@ final class JSONValidatorTests: XCTestCase {
 				else {
 					XCTFail("Failed to download \(url): got nil response with no error")
 				}
+				e.fulfill()
 			}
 			task!.resume()
-			return e
 		}
-		wait(for: expecations, timeout: 10)
+		waitForExpectations(timeout: 20)
 	}
 
 	static var allTests = [

--- a/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
+++ b/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
@@ -65,7 +65,7 @@ final class JSONValidatorTests: XCTestCase {
 			XCTAssertNotNil(url, "The url \"\(urlString)\" was invalid")
 			return url
 		}
-		let expecations = allURLs.map { url -> XCTestExpectation in
+		let expecations = Set(allURLs).map { url -> XCTestExpectation in
 			let e = expectation(description: "\(url) should be retrievable")
 			let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
 			var request = URLRequest(url: url)

--- a/JSONValidator/Tests/JSONValidatorTests/XCTestManifests.swift
+++ b/JSONValidator/Tests/JSONValidatorTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !os(macOS)
+public func allTests() -> [XCTestCaseEntry] {
+	return [
+		testCase(JSONValidatorTests.allTests),
+	]
+}
+#endif

--- a/JSONValidator/Tests/LinuxMain.swift
+++ b/JSONValidator/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import JSONValidatorTests
+
+var tests = [XCTestCaseEntry]()
+tests += JSONValidatorTests.allTests()
+XCTMain(tests)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The python files should run under both Python 2 and 3 (please try to maintain co
 
 The project is currently setup to use with the IDE `Pycharm`, so use IDE this if possible.
 
+## JSON Mod Definition
+
+The patcher reads the file `installData.json` to figure out what mods are available.  The spec for this file is defined as a `Codable` Swift struct in `JSONValidator/Sources/JSONValidator/JSONValidator.swift`
+
 ## HTTPGUI / Web Interface
 
 The web interface component is located in the httpGUI folder.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The project is currently setup to use with the IDE `Pycharm`, so use IDE this if
 
 ## JSON Mod Definition
 
-The patcher reads the file `installData.json` to figure out what mods are available.  The spec for this file is defined as a `Codable` Swift struct in `JSONValidator/Sources/JSONValidator/JSONValidator.swift`
+The patcher reads the file [installData.json](installData.json) to figure out what mods are available.  The spec for this file is defined as a `Codable` Swift struct in [JSONValidator.swift](JSONValidator/Sources/JSONValidator/JSONValidator.swift)
 
 ## HTTPGUI / Web Interface
 

--- a/travis_install_swift.sh
+++ b/travis_install_swift.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 eval "$(curl -sL https://apt.vapor.sh)"
-sudo apt install swift
+sudo apt-get install swift

--- a/travis_install_swift.sh
+++ b/travis_install_swift.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+eval "$(curl -sL https://apt.vapor.sh)"
+sudo apt install swift

--- a/travis_validate_json.sh
+++ b/travis_validate_json.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd JSONValidator
+swift test


### PR DESCRIPTION
Adds tests for validating the `installData.json` file

- Makes sure it matches the layout defined in `JSONValidator.swift`.  Note: Changes to the layout of `installData.json` will now need associated updates to its definition in `JSONValidator.swift`.  I hope its syntax isn't too hard to understand/edit for people who don't use Swift, though since I do know Swift, I'm not the one to ask about that.
- Makes sure that all files in the `fileOverrides` section override a corresponding file in the `files` section
- Makes sure each file in the `files` section has a unique name
- Makes sure all URLs are reachable (hopefully none of Travis's servers are in Japan, none of the ones that I ran on have been so far...)

I also added a scheduled (weekly for now) travis build so if we accidentally rename/delete a file listed in the JSON we'll know (maybe I should make it daily)