### PR TITLE
Unity version overrides

### DIFF
--- a/JSONValidator/Sources/JSONValidator/JSONValidator.swift
+++ b/JSONValidator/Sources/JSONValidator/JSONValidator.swift
@@ -56,7 +56,8 @@ public struct FileDefinition: Codable {
 	/// A name to identify this file for use in overrides
 	public var name: String
 	/// The url for this file
-	public var url: String
+	/// - If null, this file must be overridden or the install will fail
+	public var url: String?
 	/// The priority of this file.  Higher priority files are installed later so they will overwrite lower priority files
 	public var priority: Int
 }
@@ -67,6 +68,9 @@ public struct FileOverrideDefinition: Codable {
 	public var name: String
 	/// The OSes this override should be applied on
 	public var os: [OS]
+	/// - If non-null, will apply to the game if they have the given Unity version (Higurashi only)
+	/// - If null or missing, will apply always
+	public var unity: String?
 	/// - If true, this override will only be applied if the game is a steam version.
 	/// - If false, this override will only be applied if the game is not a steam version.
 	/// - If null, this override will be applied regardless of whether the game is a steam version.
@@ -75,7 +79,7 @@ public struct FileOverrideDefinition: Codable {
 	public var url: String
 }
 
-public enum OS: String, Codable {
+public enum OS: String, Codable, CaseIterable {
 	case mac
 	case linux
 	case windows

--- a/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
+++ b/JSONValidator/Tests/JSONValidatorTests/JSONValidatorTests.swift
@@ -58,6 +58,17 @@ final class JSONValidatorTests: XCTestCase {
 		}
 		for mod in installData.mods {
 			for submod in mod.submods {
+				for file in submod.files where file.url == nil {
+					for os in OS.allCases {
+						for steam in [true, false] {
+							if !submod.fileOverrides.contains(where: { override in
+								override.name == file.name && override.os.contains(os) && (override.steam ?? steam == steam)
+							}) {
+								XCTFail("\(mod.name) \(submod.name) \(file.name) must be overridden but a user with the os \(os) and steam \(steam) will have no overrides available")
+							}
+						}
+					}
+				}
 				let files = Set(submod.files.lazy.map { $0.name })
 				XCTAssertEqual(files.count, submod.files.count, "Multiple files were specified with the same name in \(mod.name) \(submod.name)")
 				for override in submod.fileOverrides {
@@ -75,7 +86,7 @@ final class JSONValidatorTests: XCTestCase {
 		}
 		let allURLs = installData.mods.flatMap({ mod -> [String] in
 			return mod.submods.flatMap { submod -> [String] in
-				return submod.files.map { $0.url } + submod.fileOverrides.map { $0.url }
+				return submod.files.compactMap { $0.url } + submod.fileOverrides.map { $0.url }
 			}
 		}).compactMap { urlString -> URL? in
 			let url = URL(string: urlString)

--- a/common.py
+++ b/common.py
@@ -254,7 +254,10 @@ def getModList(jsonURL):
 	:rtype: list[dict]
 	"""
 	try:
-		file = urlopen(Request(jsonURL, headers={"User-Agent": ""}))
+		if jsonURL[0:4] == "http":
+			file = urlopen(Request(jsonURL, headers={"User-Agent": ""}))
+		else:
+			file = open(jsonURL, "r")
 	except HTTPError as error:
 		print(error)
 		print("Couldn't reach 07th Mod Server to download patch info")

--- a/common.py
+++ b/common.py
@@ -55,9 +55,12 @@ def printErrorMessage(text):
 	"""
 	Prints message in red if stdout is a tty
 	"""
-	if sys.stdout.isatty:
-		print("\x1b[1m\x1b[31m" + text + "\x1b[0m")
-	else:
+	try:
+		if sys.stdout.isatty:
+			print("\x1b[1m\x1b[31m" + text + "\x1b[0m")
+		else:
+			print(text)
+	except AttributeError:
 		print(text)
 
 
@@ -65,7 +68,7 @@ def printErrorMessage(text):
 class Globals:
 	# The installer info version this installer is compatibile with
 	# Increment it when you make breaking changes to the json files
-	JSON_VERSION = 1
+	JSON_VERSION = 2
 
 	# Define constants used throughout the script. Use function calls to enforce variables as const
 	IS_WINDOWS = platform.system() == "Windows"

--- a/gameScanner.py
+++ b/gameScanner.py
@@ -7,22 +7,66 @@ try:
 except ImportError:
 	pass # Just needed for pycharm comments
 
+class OldUnityException(Exception):
+	def __init__(self, version):
+		# type: (str) -> None
+		self.version = version # type: str
+
+	def __str__(self):
+		return "Your game uses Unity "  + self.version + " which isn't supported by this mod.  Please update your game to a newer version."
+
+class FailedFileOverrideException(Exception):
+	def __init__(self, name, candidates, unity, steam):
+		# type: (str, List[ModFileOverride], Optional[str], bool) -> None
+		self.name = name
+		self.candidates = candidates # type: List[ModFileOverride]
+		self.unity = unity
+		self.steam = steam
+
+	def describe(self, candidate):
+		# type: (ModFileOverride) -> str
+		out = "("
+		if candidate.steam is not None:
+			out += "steam: " + str(candidate.steam)
+		if candidate.unity is not None:
+			if len(out) > 1:
+				out += ", "
+			out += "unity: " + candidate.unity
+		return out + ")"
+
+	def __str__(self):
+		hasUnity = any(x.unity is not None for x in self.candidates)
+		out = "Failed to find a " + self.name + " file to use, your game has the properties (steam: " + str(self.steam)
+		if hasUnity:
+			out += ", unity: " + self.unity
+		out += ") but the available versions had the requirements " + ", ".join(self.describe(candidate) for candidate in self.candidates)
+		return out
+
 #contains all the install information required to install the game to a given path
 class FullInstallConfiguration:
 	def __init__(self, subModConfig, path, isSteam):
 		# type: (SubModConfig, str, bool) -> None
-		self.subModConfig = subModConfig
-		self.installPath = path
-		self.isSteam = isSteam
+		self.subModConfig = subModConfig # type: SubModConfig
+		self.installPath = path # type: str
+		self.isSteam = isSteam # type: bool
 		self.useIPV6 = False
 
 	#applies the fileOverrides to the files to
-	def buildFileListSorted(self):
-		# type: () -> List[ModFile]
+	def buildFileListSorted(self, datadir=""):
+		# type: (str) -> List[ModFile]
 		# convert the files list into a dict
 		filesDict = {}
 		for file in self.subModConfig.files:
 			filesDict[file.name] = file
+
+		unityVersion = None
+		assetsbundlePath = os.path.join(datadir, "sharedassets0.assets")
+		if os.path.exists(assetsbundlePath):
+			with open(assetsbundlePath, "rb") as assetsBundle:
+				unityVersion = assetsBundle.read(28)[20:].decode("utf-8").rstrip("\0")
+				print("Read unity version " + unityVersion)
+				if int(unityVersion[0]) < 5:
+					raise OldUnityException(unityVersion)
 
 		for fileOverride in self.subModConfig.fileOverrides:
 			# skip overrides where OS doesn't match
@@ -33,9 +77,19 @@ class FullInstallConfiguration:
 			if fileOverride.steam is not None and fileOverride.steam != self.isSteam:
 				continue
 
+			if fileOverride.unity is not None and fileOverride.unity != unityVersion:
+				continue
+
 			# for all other overrides, overwrite the value in the filesDict with a new ModFile
 			currentModFile = filesDict[fileOverride.name]
 			filesDict[fileOverride.name] = ModFile(currentModFile.name, fileOverride.url, currentModFile.priority)
+
+		# Look for override-required files that weren't overridden
+		for key, value in filesDict.items():
+			if value.url is not None:
+				continue
+			candidates = [x for x in self.subModConfig.fileOverrides if x.name == key and common.Globals.OS_STRING in x.os]
+			raise FailedFileOverrideException(key, candidates, unity=unityVersion, steam=self.isSteam)
 
 		# sort the priority from Lowest to Highest (eg items with priority '0' will always be at start of the list)
 		# this is because the low priority items should be extracted first, so the high priority items can overwrite them.
@@ -46,17 +100,18 @@ class FullInstallConfiguration:
 # Therefore, the 'later extracted' files are higher priority, that is archives with priority 3 will overwrite priority 0,1,2 archives
 class ModFile:
 	def __init__(self, name, url, priority):
-		# type: (str, str, int) -> None
+		# type: (str, Optional[str], int) -> None
 		self.name = name
 		self.url = url
 		self.priority = priority #consider renaming this "extractionOrder"?
 
 class ModFileOverride:
-	def __init__(self, name, os, steam, url):
-		# type: (str, List[str], Optional[bool], str) -> None
+	def __init__(self, name, os, steam, unity, url):
+		# type: (str, List[str], Optional[bool], Optional[str], str) -> None
 		self.name = name
 		self.os = os #note: this is an ARRAY, eg ["mac", "linux"]
 		self.steam = steam	#this can be 'none' if the override applies to both mac and steam
+		self.unity = unity
 		self.url = url
 
 #directly represents a single submod from the json file
@@ -80,11 +135,17 @@ class SubModConfig:
 
 		self.files = [] # type: List[ModFile]
 		for subModFile in subMod['files']:
-			self.files.append(ModFile(name=subModFile['name'], url = subModFile['url'], priority=subModFile['priority']))
+			self.files.append(ModFile(name=subModFile['name'], url = subModFile.get('url'), priority=subModFile['priority']))
 
 		self.fileOverrides = [] # type: List[ModFileOverride]
 		for subModFileOverride in subMod['fileOverrides']:
-			self.fileOverrides.append(ModFileOverride(name=subModFileOverride['name'], os=subModFileOverride['os'], steam=subModFileOverride['steam'], url=subModFileOverride['url']))
+			self.fileOverrides.append(ModFileOverride(
+				name=subModFileOverride['name'],
+				os=subModFileOverride['os'],
+				steam=subModFileOverride.get('steam'),
+				unity=subModFileOverride.get('unity'),
+				url=subModFileOverride['url']
+			))
 
 	def __repr__(self):
 		return "Type: [{}] Game Name: [{}]".format(self.modName, self.subModName)

--- a/higurashiInstaller.py
+++ b/higurashiInstaller.py
@@ -44,7 +44,7 @@ class Installer:
 		self.downloadDir = self.info.subModConfig.modName + " Downloads"
 		self.extractDir = self.info.subModConfig.modName + " Extraction"
 
-		self.downloaderAndExtractor = common.DownloaderAndExtractor(modFileList=self.info.buildFileListSorted(),
+		self.downloaderAndExtractor = common.DownloaderAndExtractor(modFileList=self.info.buildFileListSorted(datadir=self.dataDirectory),
 		                                                            downloadTempDir=self.downloadDir,
 		                                                            extractionDir=self.extractDir)
 

--- a/httpGUI.py
+++ b/httpGUI.py
@@ -299,7 +299,14 @@ class InstallerGUI:
 		if self.threadHandle and self.threadHandle.is_alive():
 			return False
 
-		self.threadHandle = threading.Thread(target=installerFunction, args=(fullInstallSettings,))
+		def errorPrintingInstaller(args):
+			try:
+				installerFunction(args)
+			except Exception as e:
+				print("Install failed due to error: " + str(e))
+				raise
+
+		self.threadHandle = threading.Thread(target=errorPrintingInstaller, args=(fullInstallSettings,))
 		self.threadHandle.setDaemon(True)  # Use setter for compatability with Python 2
 		self.threadHandle.start()
 

--- a/installData.json
+++ b/installData.json
@@ -1,5 +1,5 @@
 {
-	"version": 1,
+	"version": 2,
 	"mods": [
 		{
 			"family": "higurashi",
@@ -20,8 +20,8 @@
 						{"name": "script",  "url":"https://07th-mod.com/latest.php?repository=onikakushi",          "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "movie",   "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Onikakushi-Movie_UNIX.7z"},
-						{"name": "ui",      "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Onikakushi-UI_UNIX.7z"}
+						{"name": "movie",   "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Onikakushi-Movie_UNIX.7z"},
+						{"name": "ui",      "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Onikakushi-UI_UNIX.7z"}
 					]
 				}
 			]
@@ -45,8 +45,8 @@
 						{"name": "script",  "url":"https://07th-mod.com/latest.php?repository=watanagashi",         "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "movie",   "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Watanagashi-Movie_UNIX.7z"},
-						{"name": "ui",      "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Watanagashi-UI_UNIX.7z"}
+						{"name": "movie",   "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Watanagashi-Movie_UNIX.7z"},
+						{"name": "ui",      "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Watanagashi-UI_UNIX.7z"}
 					]
 				}
 			]
@@ -66,14 +66,15 @@
 						{"name": "cgalt",   "url":"https://07th-mod.com/rikachama/Tatarigoroshi-CGAlt.7z",          "priority": 0},
 						{"name": "movie",   "url":"https://07th-mod.com/rikachama/Tatarigoroshi-Movie.7z",          "priority": 0},
 						{"name": "voices",  "url":"https://07th-mod.com/rikachama/Tatarigoroshi-Voices.7z",         "priority": 0},
-						{"name": "ui",      "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI.7z",             "priority": 0},
+						{"name": "ui",      "url": null,                                                            "priority": 0},
 						{"name": "script",  "url":"https://07th-mod.com/latest.php?repository=tatarigoroshi",       "priority": 0}
 					],
 					"fileOverrides" : [
 						{"name": "movie",   "os": ["linux", "mac"], "steam": null,  "url":"https://07th-mod.com/rikachama/Tatarigoroshi-Movie_UNIX.7z"},
-						{"name": "ui",      "os": ["windows"], 	    "steam": false, "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI_MG.7z"},
-						{"name": "ui",      "os": ["linux", "mac"], "steam": true,  "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI_UNIX.7z"},
-						{"name": "ui",      "os": ["linux", "mac"], "steam": false, "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI_UNIX-MG.7z"}
+						{"name": "ui",      "os": ["windows"], 	    "unity": "5.4.0f1", "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI.7z"},
+						{"name": "ui",      "os": ["windows"], 	    "unity": "5.3.4p1", "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI_MG.7z"},
+						{"name": "ui",      "os": ["linux", "mac"], "unity": "5.4.0f1", "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI_UNIX.7z"},
+						{"name": "ui",      "os": ["linux", "mac"], "unity": "5.3.4p1", "url":"https://07th-mod.com/rikachama/Tatarigoroshi-UI_UNIX-MG.7z"}
 					]
 				}
 			]
@@ -98,8 +99,8 @@
 						{"name": "script",  "url":"https://07th-mod.com/latest.php?repository=himatsubushi",        "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "movie",   "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Himatsubushi-Movie_UNIX.7z"},
-						{"name": "ui",      "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Himatsubushi-UI_UNIX.7z"}
+						{"name": "movie",   "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Himatsubushi-Movie_UNIX.7z"},
+						{"name": "ui",      "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Himatsubushi-UI_UNIX.7z"}
 					]
 				}
 			]
@@ -123,8 +124,8 @@
 						{"name": "script",  "url":"https://07th-mod.com/latest.php?repository=meakashi",            "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "movie",   "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Meakashi-Movie_UNIX.7z"},
-						{"name": "ui",      "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Meakashi-UI_UNIX.7z"}
+						{"name": "movie",   "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Meakashi-Movie_UNIX.7z"},
+						{"name": "ui",      "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Meakashi-UI_UNIX.7z"}
 					]
 				}
 			]
@@ -148,8 +149,8 @@
 						{"name": "script",  "url":"https://07th-mod.com/latest.php?repository=tsumihoroboshi",      "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "movie",   "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Tsumihoroboshi-Movie_UNIX.7z"},
-						{"name": "ui",      "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Tsumihoroboshi-UI_UNIX.7z"}
+						{"name": "movie",   "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Tsumihoroboshi-Movie_UNIX.7z"},
+						{"name": "ui",      "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Tsumihoroboshi-UI_UNIX.7z"}
 					]
 				}
 			]
@@ -176,8 +177,8 @@
 						{"name": "script",    "url":"https://07th-mod.com/latest.php?repository=higurashi-console-arcs", "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "movie",   "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/ConsoleArcs-Movie_UNIX.7z"},
-						{"name": "ui",      "os": ["mac", "linux"], "steam": null, "url":"https://07th-mod.com/rikachama/Himatsubushi-UI_UNIX.7z"}
+						{"name": "movie",   "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/ConsoleArcs-Movie_UNIX.7z"},
+						{"name": "ui",      "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/Himatsubushi-UI_UNIX.7z"}
 					]
 				}
 			]
@@ -198,8 +199,8 @@
 						{"name": "exe", "url":"https://07th-mod.com/Beato-voice/Umineko1to4.exe", "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "exe", "os":["linux"], "steam": null, "url":"https://07th-mod.com/Beato-voice/Umineko1to4"},
-						{"name": "exe", "os":["mac"], "steam": null, "url":"https://07th-mod.com/Beato-voice/Umineko1to4.app.zip"}
+						{"name": "exe", "os":["linux"], "url":"https://07th-mod.com/Beato-voice/Umineko1to4"},
+						{"name": "exe", "os":["mac"],   "url":"https://07th-mod.com/Beato-voice/Umineko1to4.app.zip"}
 					]
 				},
 				{
@@ -214,8 +215,8 @@
 					],
 					"fileOverrides" : [
 						{"name": "os-specific-update", "os":["mac", "linux"], "steam": null, "url":"https://07th-mod.com/Beato/1080p/Umineko-Update-1080p-v3_2019_01_03_MAC_LINUX.7z"},
-						{"name": "exe", "os":["linux"], "steam": null, "url":"https://07th-mod.com/Beato/1080p/Umineko1to4"},
-						{"name": "exe", "os":["mac"], "steam": null, "url":"https://07th-mod.com/Beato/1080p/Umineko1to4.app.zip"}
+						{"name": "exe", "os":["linux"], "url":"https://07th-mod.com/Beato/1080p/Umineko1to4"},
+						{"name": "exe", "os":["mac"],   "url":"https://07th-mod.com/Beato/1080p/Umineko1to4.app.zip"}
 					]
 				}
 			]
@@ -237,8 +238,8 @@
 						{"name": "exe", "url":"https://07th-mod.com/Bern-voice/Umineko5to8.exe", "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "exe", "os":["linux"], "steam": null, "url":"https://07th-mod.com/Bern-voice/Umineko5to8"},
-						{"name": "exe", "os":["mac"], "steam": null, "url":"https://07th-mod.com/Bern-voice/Umineko5to8.app.zip"}
+						{"name": "exe", "os":["linux"], "url":"https://07th-mod.com/Bern-voice/Umineko5to8"},
+						{"name": "exe", "os":["mac"],   "url":"https://07th-mod.com/Bern-voice/Umineko5to8.app.zip"}
 					]
 				},
 				{
@@ -249,8 +250,8 @@
 						{"name": "exe", "url":"https://07th-mod.com/Bern/Umineko5to8.exe", "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "exe", "os":["linux"], "steam": null, "url":"https://07th-mod.com/Bern/Umineko5to8"},
-						{"name": "exe", "os":["mac"], "steam": null, "url":"https://07th-mod.com/Bern/Umineko5to8.app.zip"}
+						{"name": "exe", "os":["linux"], "url":"https://07th-mod.com/Bern/Umineko5to8"},
+						{"name": "exe", "os":["mac"],   "url":"https://07th-mod.com/Bern/Umineko5to8.app.zip"}
 					]
 				},
 				{
@@ -262,8 +263,8 @@
 						{"name": "exe", "url":"https://07th-mod.com/Bern/Umineko5to8.exe", "priority": 0}
 					],
 					"fileOverrides" : [
-						{"name": "exe", "os":["linux"], "steam": null, "url":"https://07th-mod.com/Bern/Umineko5to8"},
-						{"name": "exe", "os":["mac"], "steam": null, "url":"https://07th-mod.com/Bern/Umineko5to8.app.zip"}
+						{"name": "exe", "os":["linux"], "url":"https://07th-mod.com/Bern/Umineko5to8"},
+						{"name": "exe", "os":["mac"],   "url":"https://07th-mod.com/Bern/Umineko5to8.app.zip"}
 					]
 				}
 			]

--- a/installerGUI.py
+++ b/installerGUI.py
@@ -160,12 +160,19 @@ class InstallerGUI:
 			"umineko": uminekoInstaller.mainUmineko
 		}.get(fullInstallSettings.subModConfig.family, None)
 
+		def errorPrintingInstaller(args):
+			try:
+				installerFunction(args)
+			except Exception as e:
+				print("Install failed due to error: " + str(e))
+				raise
+
 		if not installerFunction:
 			messagebox.showerror("Error - Unknown Game Family",
 			                     "I don't know how to install [{}] family of games. Please notify 07th-mod developers.")
 			return
 
-		t = threading.Thread(target=installerFunction, args=(fullInstallSettings,))
+		t = threading.Thread(target=errorPrintingInstaller, args=(fullInstallSettings,))
 		t.setDaemon(True)  # Use setter for compatability with Python 2
 		t.start()
 

--- a/main.py
+++ b/main.py
@@ -54,7 +54,11 @@ if __name__ == "__main__":
 	common.Globals.scanForExecutables()
 
 	# Scan for moddable games on the user's computer before starting installation
-	modList = common.getModList("https://raw.githubusercontent.com/07th-mod/python-patcher/master/installData.json")
+	if os.path.exists("installData.json"):
+		# Use local `installData.json` if it's there (if cloned from github)
+		modList = common.getModList("installData.json")
+	else:
+		modList = common.getModList("https://raw.githubusercontent.com/07th-mod/python-patcher/master/installData.json")
 
 	subModconfigList = []
 	for mod in modList:

--- a/travis_build_script.py
+++ b/travis_build_script.py
@@ -44,7 +44,7 @@ output_folder = 'travis_installer_output'
 bootstrap_copy_folder = 'travis_installer_bootstrap_copy'
 
 # No wildcards allowed in these paths to be ignored
-ignore_paths = [staging_folder, output_folder, bootstrap_copy_folder, 'httpGUI/node_modules', 'bootstrap', '.git', '.idea', '.gitignore', '.travis.yml', '__pycache__']
+ignore_paths = [staging_folder, output_folder, bootstrap_copy_folder, 'JSONValidator', 'installData.json', 'httpGUI/node_modules', 'bootstrap', '.git', '.idea', '.gitignore', '.travis.yml', '__pycache__']
 ignore_paths_realpaths = set([os.path.realpath(x) for x in ignore_paths])
 
 def ignore_filter(folderPath, folderContents):


### PR DESCRIPTION
- Installer will use a `installData.json` that is placed in the same folder as it if one exists (mainly for testing with local copies)
- Adds support for detecting games' Unity versions and applying overrides based on that
- Automatically rejects games with Unity versions <5
- Adds support for a file to have a `null` URL, which will cause the install to fail if no overrides get applied
- Switched Tatarigoroshi from branching on Steam to branching on Unity version
- Note: This is a breaking change, and the JSON version has been updated accordingly.  Once this is merged we should make sure to make a new tag so people can download an installer that works with the install data file.