### PR TITLE
Fix some wording in the installer

### DIFF
--- a/httpGUI/installer.html
+++ b/httpGUI/installer.html
@@ -339,7 +339,6 @@
 														<li>PS3 sprites</li>
 														<li>PS3 CGs (event images)</li>
 														<li>PS3 Backgrounds</li>
-														<li>Remake of original OP in 1080p OR PS3 OP movie (user option on startup)</li>
 														<li>DOES NOT add shader effects or lipsync from the PS3 game.</li>
 													</ul>
 												</div>
@@ -352,7 +351,6 @@
 														<li>PS3 sprites</li>
 														<li>PS3 CGs (event images)</li>
 														<li>PS3 Backgrounds</li>
-														<li>Remake of original OP in 1080p OR PS3 OP movie (user option on startup)</li>
 														<li>DOES NOT add shader effects or lipsync from the PS3 game.</li>
 													</ul>
 												</div>

--- a/installData.json
+++ b/installData.json
@@ -403,7 +403,7 @@
 					"radio": [
 						{"name": "No BGM Changes", "description": "Use the default Background Music"},
 						{
-							"name": "Restore BGM", "description": "Restores censored system0.ogg BGM",
+							"name": "Restore BGM", "description": "Restores uncensored system0.ogg BGM",
 							"data": {"url": "https://07th-mod.com/Bern/umineko-qa-bgm-restoration.zip", "relativeExtractionPath": ".", "priority": 10}
 						}
 					]
@@ -466,7 +466,7 @@
 					"radio": [
 						{"name": "No BGM Changes", "description": "Use the default Background Music"},
 						{
-							"name": "Restore BGM", "description": "Restores censored system0.ogg BGM",
+							"name": "Restore BGM", "description": "Restores uncensored system0.ogg BGM",
 							"data": {"url": "https://07th-mod.com/Bern/umineko-qa-bgm-restoration.zip", "relativeExtractionPath": ".", "priority": 10}
 						}
 					]


### PR DESCRIPTION
This removes the claim that the user can choose the OPs for answer arcs (that's only true for question arcs) and changes "Restore censored BGM" to "Restore uncensored BGM" to make it more clear that we're not putting censorship in but taking it out.