### PR TITLE
Unicode paths

### DIFF
--- a/commandLineParser.py
+++ b/commandLineParser.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import re
 
 class AriaStatusUpdate:

--- a/common.py
+++ b/common.py
@@ -386,7 +386,7 @@ def getModList(jsonURL):
 		if version > Globals.JSON_VERSION:
 			printErrorMessage("Your installer is out of date.")
 			printErrorMessage("Please download the latest version of the installer and try again.")
-			print("\nYour installer is compatible with mod listings up to version " + str(Globals.JSON_VERSION) + " but the latest listing is version " + str(version))
+			print("\nYour installer is compatible with mod listings up to version {} but the latest listing is version {}".format(Globals.JSON_VERSION, version))
 			exitWithError()
 	except KeyError:
 		print("Warning: The mod info listing is missing a version number.  Things might not work.")
@@ -568,7 +568,7 @@ class DownloaderAndExtractor:
 		# extract or copy all files from the download folder to the game directory
 		for i, extractableItem in enumerate(self.extractList):
 			overallPercentage = self.downloadProgressAmount + int(i*self.extractionProgressAmount/len(self.extractList))
-			commandLineParser.printSeventhModStatusUpdate(overallPercentage, "Extracting " + str(extractableItem))
+			commandLineParser.printSeventhModStatusUpdate(overallPercentage, "Extracting {}".format(extractableItem))
 			fileNameNoExt, extension = os.path.splitext(extractableItem.filename)
 
 			#TODO: the '.u' and '.utf' logic is specific to umineko - shouldn't be in this class
@@ -591,9 +591,9 @@ class DownloaderAndExtractor:
 
 	def printPreview(self):
 		print("\nFirst these files will be downloaded (Total Download Size: {}):".format(prettyPrintFileSize(self.totalDownloadSize())))
-		print('\n - '.join([''] + self.downloadList))
+		print('\n - '.join(self.downloadList))
 		print("\nThen these files will be extracted or copied:")
-		print('\n - '.join([''] + [str(x) for x in self.extractList]))
+		print('\n - '.join(['{}'.format(x) for x in self.extractList]))
 		print()
 
 	def totalDownloadSize(self):

--- a/common.py
+++ b/common.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import datetime
 import re
@@ -117,6 +117,8 @@ class Globals:
 
 	BUILD_INFO = 'Build info not yet retrieved'
 	INSTALL_LOCK_FILE_PATH = 'lockfile.lock'
+
+	IS_PYTHON_2 = sys.version_info.major == 2
 
 	@staticmethod
 	def scanForExecutables():

--- a/gameScanner.py
+++ b/gameScanner.py
@@ -31,7 +31,7 @@ class FailedFileOverrideException(Exception):
 		# type: (ModFileOverride) -> str
 		out = "("
 		if candidate.steam is not None:
-			out += "steam: " + str(candidate.steam)
+			out += "steam: {}".format(candidate.steam)
 		if candidate.unity is not None:
 			if len(out) > 1:
 				out += ", "
@@ -40,9 +40,9 @@ class FailedFileOverrideException(Exception):
 
 	def __str__(self):
 		hasUnity = any(x.unity is not None for x in self.candidates)
-		out = "Failed to find a " + self.name + " file to use, your game has the properties (steam: " + str(self.steam)
+		out = "Failed to find a {} file to use, your game has the properties (steam: {}".format(self.name, self.steam)
 		if hasUnity:
-			out += ", unity: " + str(self.unity)
+			out += ", unity: {}".format(self.unity)
 		out += ") but the available versions had the requirements " + ", ".join(self.describe(candidate) for candidate in self.candidates)
 		return out
 
@@ -160,7 +160,7 @@ class ModOptionParser:
 		# Sort according to priority - higher priority items will be extracted later, overwriting lower priority items.
 		print('MOD OPTIONS:\n')
 		for modOption in self.config.subModConfig.modOptions:
-			print('  - ' + str(modOption))
+			print('  - {}'.format(modOption))
 			if modOption.value:
 				if modOption.type == 'downloadAndExtract' and modOption.data is not None:
 					self.downloadAndExtractOptionsByPriority.append(

--- a/gameScanner.py
+++ b/gameScanner.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import glob
 import json
 import re
@@ -6,6 +8,7 @@ import common
 import os
 import subprocess
 import traceback
+
 try:
 	from typing import List, Optional
 except ImportError:
@@ -271,9 +274,10 @@ def findPossibleGamePathsWindows():
 	# now that we know the steam path, search the "Steam\config\config.vdf" file for extra install paths
 	# this is a purely optional step, so it's OK if it fails
 	try:
+		import io
 		baseInstallFolderRegex = re.compile(r'^\s*"BaseInstallFolder_\d+"\s*"([^"]+)"', re.MULTILINE)
 		steamConfigVDFLocation = os.path.join(defaultSteamPath, r'config\config.vdf')
-		with open(steamConfigVDFLocation, 'r') as configVDFFile:
+		with io.open(steamConfigVDFLocation, 'r', encoding='UTF-8') as configVDFFile:
 			allSteamPaths += baseInstallFolderRegex.findall(configVDFFile.read())
 	except Exception as e:
 		traceback.print_exc()

--- a/higurashiInstaller.py
+++ b/higurashiInstaller.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import traceback
 

--- a/httpGUI.py
+++ b/httpGUI.py
@@ -1,6 +1,5 @@
-# TODO: test on python 2.7
 # see https://blog.anvileight.com/posts/simple-python-http-server/
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import itertools
 import os

--- a/httpGUI.py
+++ b/httpGUI.py
@@ -391,7 +391,7 @@ class InstallerGUI:
 			try:
 				installerFunction(args)
 			except Exception as e:
-				print(common.Globals().INSTALLER_MESSAGE_ERROR_PREFIX + str(e))
+				print('{}{}'.format(common.Globals().INSTALLER_MESSAGE_ERROR_PREFIX, e))
 				raise
 			common.tryDeleteLockFile()
 

--- a/logger.py
+++ b/logger.py
@@ -120,7 +120,7 @@ class Logger(object):
 			self.secondaryLogFile = open(newLogFilePath, "a")
 			print("Successfully created secondary log file at: [{}]".format(newLogFilePath))
 		except Exception as e:
-			print("Couldn't create secondary log at: [{}] Error: {}".format(newLogFilePath, str(e)))
+			print("Couldn't create secondary log at: [{}] Error: {}".format(newLogFilePath, e))
 
 def getGlobalLogger():
 	# type: () -> Logger

--- a/logger.py
+++ b/logger.py
@@ -1,7 +1,12 @@
+from __future__ import unicode_literals
+
 import os
 import shutil
 import sys
 from common import makeDirsExistOK
+from common import Globals
+
+import io
 
 try:
 	import queue
@@ -34,7 +39,7 @@ class Logger(object):
 		self.logPath = logPath
 		self.terminal = sys.stdout
 		makeDirsExistOK(os.path.dirname(logPath))
-		self.logFile = open(logPath, "a")
+		self.logFile = io.open(logPath, "a", encoding='UTF-8')
 		self.secondaryLogFile = None
 		self.callbacks = {}
 		self.queue = queue.Queue(maxsize=100000)
@@ -43,6 +48,9 @@ class Logger(object):
 		self.terminal.write(message)
 
 	def write(self, message, runCallbacks=True):
+		if Globals.IS_PYTHON_2 and isinstance(message, str):
+			message = message.decode(encoding='UTF-8', errors='replace')
+
 		self.terminal.write(message)
 		self.logFile.write(message)
 		if self.secondaryLogFile is not None:
@@ -117,7 +125,7 @@ class Logger(object):
 				fileToClose.close()
 				print("Closed log file at: [{}]".format(newLogFilePath))
 
-			self.secondaryLogFile = open(newLogFilePath, "a")
+			self.secondaryLogFile = open(newLogFilePath, "a", encoding='UTF-8')
 			print("Successfully created secondary log file at: [{}]".format(newLogFilePath))
 		except Exception as e:
 			print("Couldn't create secondary log at: [{}] Error: {}".format(newLogFilePath, e))

--- a/uminekoInstaller.py
+++ b/uminekoInstaller.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import commandLineParser
 import common
 import os, shutil, subprocess


### PR DESCRIPTION
I tested installing on a unicode path ("W:\SteamLibrary\steamapps\common\Higurashi When They 😂") and it seems to run OK on Windows with Python 3. However due to a bug in Python 2.7 on windows, the subprocess.popen call fails (https://stackoverflow.com/questions/9941064/subprocess-popen-with-a-unicode-path). However up until that point, there weren't any problems on Python 2.7.

I have made two commits 
- one where I replace str(...) calls with format() (because on 2.7, if you call str(something unicode) it fails, 
- The other one's changes are listed below:

> Open logfile with UTF-8 encoding using io.open, use unicode_literals everywhere
> 
> - io.open is used on python 2 as normal open() on python 2 does not have a 'encoding' argument
> - io.open is slower on python 2 than normal 'open()' as it's a pure python implementation
> - io.open is the same as open() on python 3
> - messages must be converted to "unicode" if they are "str", on Python 2 only, during logging, as the write() function doesn't accept unicode objects
> - unicode_literals are necessary because format() requires the format string be unicode if one of the parameters is unicode
> - Steam config VDF file is read as unicode just incase it contains any unicode

although I said "io.open is slower on python 2", I haven't noticed it in our application - that's just what I have read online.

An option is to just say we don't support unicode paths on Mac / python 2.7. In that case we only need to add encoding=utf-8 to the open() calls, I think.

----

More links
- Change default encoding hack which I didn't use: https://stackoverflow.com/questions/2276200/changing-default-encoding-of-python
- Using io.open: https://stackoverflow.com/questions/10971033/backporting-python-3-openencoding-utf-8-to-python-2
- Using format() on a unicode string: https://stackoverflow.com/questions/3235386/python-using-format-on-a-unicode-escaped-string
