### PR TITLE
Curl fallback and fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ matrix:
   include:
   # Use this linux machine to build the linux release and run Swift tests
   - name: Build Linux Installer and Run Swift Tests
-    python: 3.7
+    python: 3.8
     dist: xenial
     before_install:
     - sudo apt-get install -y aria2
     - sudo apt-get install -y p7zip-full
     - bash travis_install_swift.sh
+    - pip3 install --upgrade pip
     env:
       - BUILD_MODE=NORMAL
       - RUN_TESTS=TRUE
@@ -19,14 +20,13 @@ matrix:
     language: shell
     before_install:
     - choco install aria2
-    - choco install python
+    - choco install python3
     - choco install rust-ms --forcex86
-    - python -m pip install --upgrade pip
     env:
-      - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+    # ----------- UPDATE THIS LINE EACH TIME PYTHON VERSION CHANGES ----------------
+      - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+    # ------------------------------------------------------------------------------
       - BUILD_MODE=WINDOWS
-# TODO: Not sure if upgrading pip is necessary. This would save time across all machines.
-install: pip3 install --upgrade pip
 # The below tasks are run across all machines, but gated using if statements on the environment variables
 script:
 - if [ "$BUILD_MODE" = "NORMAL" ]; then python travis_build_script.py && bash travis_validate_json.sh ; fi

--- a/travis_build_script.py
+++ b/travis_build_script.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import datetime
 
+print("--- Running 07th-Mod Installer Build using Python {} ---".format(sys.version))
+
 BUILD_LINUX_MAC = True
 if len(sys.argv) == 2:
 	if "win" in sys.argv[1].lower():
@@ -92,14 +94,17 @@ try_remove_tree(bootstrap_copy_folder)
 try_remove_tree(output_folder)
 try_remove_tree(staging_folder)
 
+# Fix for Python 3.8 - For copytree to ignore folders correctly, they must exist before the copy process begins
 # Make sure the output folder exists
 os.makedirs(output_folder, exist_ok=True)
+os.makedirs(staging_folder, exist_ok=True)
+os.makedirs(bootstrap_copy_folder, exist_ok=True)
 
 # copy bootstrap folder to a temp folder
-shutil.copytree('bootstrap', bootstrap_copy_folder)
+shutil.copytree('bootstrap', bootstrap_copy_folder, dirs_exist_ok=True)
 
 # copy all files in the root github directory, except those in ignore_patterns
-shutil.copytree('.', staging_folder, ignore=ignore_filter)
+shutil.copytree('.', staging_folder, ignore=ignore_filter, dirs_exist_ok=True)
 
 # Save the build information in the staging folder. Will later be read by installer.
 with open(os.path.join(staging_folder, 'build_info.txt'), 'w', encoding='utf-8') as build_info_file:


### PR DESCRIPTION
This PR should fix at least one (possibly both, but one of the errors was not re-tested) of the MacOS SSL issues mentioned in #77 .

It also fixes builds failing recently (was due to the python3 module of chocolatey upgrading to python 3.8)