### PR TITLE
Find Steam installs on Linux

### DIFF
--- a/gameScanner.py
+++ b/gameScanner.py
@@ -115,6 +115,9 @@ def getMaybeGamePaths():
 		hardCodedGameContainingPaths.append("~/Library/Application Support/Steam/steamapps/common/")
 	if common.Globals.IS_WINDOWS:
 		hardCodedGameContainingPaths.append("c:/games/Mangagamer")
+	if common.Globals.IS_LINUX:
+		hardCodedGameContainingPaths.append("~/.steam/steam/steamapps/common/")
+		hardCodedGameContainingPaths.append("~/.steam/steambeta/steamapps/common/")
 
 	for hardCodedPath in hardCodedGameContainingPaths:
 		try:


### PR DESCRIPTION
It seems that on Linux `~/.steam/steam/` (or `~/.steam/steambeta`) will ALWAYS be a symlink to the steam install directory.