### PR TITLE
Find Steam installs on Linux

### DIFF
--- a/gameScanner.py
+++ b/gameScanner.py
@@ -115,6 +115,9 @@ def getMaybeGamePaths():
 		hardCodedGameContainingPaths.append("~/Library/Application Support/Steam/steamapps/common/")
 	if common.Globals.IS_WINDOWS:
 		hardCodedGameContainingPaths.append("c:/games/Mangagamer")
+	if common.Globals.IS_LINUX:
+		hardCodedGameContainingPaths.append(os.path.realpath(os.path.expanduser("~/.steam/steam/steamapps/common/")))
+		hardCodedGameContainingPaths.append(os.path.realpath(os.path.expanduser("~/.steam/steambeta/steamapps/common/")))
 
 	for hardCodedPath in hardCodedGameContainingPaths:
 		try:

--- a/gameScanner.py
+++ b/gameScanner.py
@@ -116,10 +116,11 @@ def getMaybeGamePaths():
 	if common.Globals.IS_WINDOWS:
 		hardCodedGameContainingPaths.append("c:/games/Mangagamer")
 	if common.Globals.IS_LINUX:
-		hardCodedGameContainingPaths.append(os.path.realpath(os.path.expanduser("~/.steam/steam/steamapps/common/")))
-		hardCodedGameContainingPaths.append(os.path.realpath(os.path.expanduser("~/.steam/steambeta/steamapps/common/")))
+		hardCodedGameContainingPaths.append("~/.steam/steam/steamapps/common/")
+		hardCodedGameContainingPaths.append("~/.steam/steambeta/steamapps/common/")
 
-	for hardCodedPath in hardCodedGameContainingPaths:
+	for hardCodedPathNotNormalized in hardCodedGameContainingPaths:
+		hardCodedPath = os.path.realpath(os.path.expanduser(hardCodedPathNotNormalized))
 		try:
 			for gameFolderName in os.listdir(hardCodedPath):
 				gameFolderPath = os.path.normpath(os.path.join(hardCodedPath, gameFolderName))


### PR DESCRIPTION
It seems that on Linux `~/.steam/steam/` (or `~/.steam/steambeta`) will ALWAYS be a symlink to the steam install directory.

See #91 

I had to use `os.path.expanduser` in order to get `~` to work, how does the Mac path work?