### PR TITLE
Use old DLL for GOG version of Matsuri

### DIFF
--- a/httpGUI/installer.html
+++ b/httpGUI/installer.html
@@ -215,10 +215,6 @@
 												<h4 class="uppercase ">{{selectedSubMod.subModName}} Patch</h4>
 												<!-- Show the appropriate description depending on the descriptionID -->
 												<div v-if="selectedSubMod.descriptionID === 'higurashiFull'">
-													<div v-if="selectedSubMod.modName === 'Matsuribayashi Ch.8'">
-														⚠️<strong style="color: red">WARNING for GOG users:</strong> The GOG version of Matsuribayashi Ch.8 is currently incompatible with the 'full' patch of our mod. We are waiting for Mangagamer to update the game so that it will work.<br><strong>If you have the GOG version of the game, DO NOT install the mod</strong>, and instead wait for us to announce that the mod is compatible with the GOG release.</strong>
-													</div>
-													<br>
 													<div v-if="selectedSubMod.modName === 'Console Arcs'">
 														<strong style="color: red">WARNING: This will overwrite your Himatsubushi Ch.4 installation with the console arcs.</strong><br>
 														For best results, we recommend you install to a fresh, unmodded Himatsubushi Ch.4 installation, however overwriting a modded version will probably still work.<br>

--- a/httpGUI/python-patcher-lib.js
+++ b/httpGUI/python-patcher-lib.js
@@ -244,9 +244,7 @@ Continue install anyway?`)) {
             app.scriptNeedsUpdate = responseData.scriptNeedsUpdate;
             app.numUpdatesRequired = responseData.numUpdatesRequired;
             app.fullUpdateRequired = responseData.fullUpdateRequired;
-            if (app.selectedSubMod.modName === 'Matsuribayashi Ch.8' && app.selectedSubMod.subModName === 'full' && app.selectedInstallPath.includes('GOG')) {
-              alert("WARNING: The GOG version of Matsuribayashi Ch.8 is currently incompatible with the 'full' patch of our mod. We are waiting for Mangagamer to update the game so that it will work.\n\nWe suggest you DO NOT install the game, and instead wait us to announce that the mod is compatible with the GOG release.");
-            }
+
             if (responseData.partialReinstallDetected) {
               alert("WARNING: It appears you re-installed the game without fully deleting the game folder. If you wish to update or re-install, you MUST click the\n'RE-INSTALL FROM SCRATCH' button at the bottom of this page, otherwise the mod may not work!\n\nFor more info, see Install Instructions - Uninstalling Games:\nhttps://07th-mod.com/wiki/Higurashi/Higurashi-Part-1---Voice-and-Graphics-Patch/#uninstalling-games\n\nIf this message incorrect (you did not partially re-install the game), ignore this message, and let the mod team know.");
             }

--- a/installData.json
+++ b/installData.json
@@ -589,14 +589,16 @@
 						{"name": "movie",   "url": "https://07th-mod.com/rikachama/video/Matsuribayashi-Movie.7z", "priority": 0},
 						{"name": "voices",  "url": "https://07th-mod.com/rikachama/voice/Matsuribayashi-Voices.7z", "priority": 0},
 						{"name": "ui",      "url": null, "priority": 0},
-						{"name": "script",  "url": "https://07th-mod.com/latest.php?repository=matsuribayashi", "priority": 5}
+						{"name": "script",  "url": "https://07th-mod.com/latest.php?repository=matsuribayashi", "priority": 5},
+						{"name": "dll", "url": "https://07th-mod.com/rikachama/matsuri-dll-override/this-file-intentionally-left-blank.7z", "priority": 10}
 					],
 					"fileOverrides": [
 						{"name": "movie", "id": "movie-unix", "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/video/Matsuribayashi-Movie_UNIX.7z"},
 						{"name": "ui",    "id": "ui-windows", "os": ["windows"],      "unity": "5.6.7f1", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=win&unity=5.6.7f1"},
 						{"name": "ui",    "id": "ui-unix", "os": ["mac", "linux"], "unity": "5.6.7f1", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=unix&unity=5.6.7f1"},
 						{"name": "ui",    "id": "ui-windows", "os": ["windows"],      "unity": "2017.2.5", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=win&unity=2017.2.5"},
-						{"name": "ui",    "id": "ui-unix", "os": ["mac", "linux"], "unity": "2017.2.5", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=unix&unity=2017.2.5"}
+						{"name": "ui",    "id": "ui-unix", "os": ["mac", "linux"], "unity": "2017.2.5", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=unix&unity=2017.2.5"},
+						{"name": "dll", "id": "dll-gog", "os": ["windows", "linux"], "unity": "5.6.7f1", "url": "https://07th-mod.com/rikachama/matsuri-dll-override/good-old-dll.7z"}
 					]
 				},
 				{

--- a/installData.json
+++ b/installData.json
@@ -593,6 +593,8 @@
 					],
 					"fileOverrides": [
 						{"name": "movie", "id": "movie-unix", "os": ["mac", "linux"], "url":"https://07th-mod.com/rikachama/video/Matsuribayashi-Movie_UNIX.7z"},
+						{"name": "ui",    "id": "ui-windows", "os": ["windows"],      "unity": "5.6.7f1", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=win&unity=5.6.7f1"},
+						{"name": "ui",    "id": "ui-unix", "os": ["mac", "linux"], "unity": "5.6.7f1", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=unix&unity=5.6.7f1"},
 						{"name": "ui",    "id": "ui-windows", "os": ["windows"],      "unity": "2017.2.5", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=win&unity=2017.2.5"},
 						{"name": "ui",    "id": "ui-unix", "os": ["mac", "linux"], "unity": "2017.2.5", "url":"https://07th-mod.com/ui.php?chapter=matsuribayashi&os=unix&unity=2017.2.5"}
 					]

--- a/versionData.json
+++ b/versionData.json
@@ -146,7 +146,9 @@
 			{"id": "script",              "version": "1.0.0"},
 			{"id": "movie-unix",          "version": "1.0.0"},
 			{"id": "ui-windows",          "version": "1.0.0"},
-			{"id": "ui-unix",             "version": "1.0.0"}
+			{"id": "ui-unix",             "version": "1.0.0"},
+			{"id": "dll",                 "version": "1.0.0"},
+			{"id": "dll-gog",             "version": "1.0.0"}
 		]
 	},
 	{


### PR DESCRIPTION
Please replace the DLL in `rikachama/matsuri-dll-override/good-old-dll.7z` with a working one before merging.