### PR TITLE
Detect game when Steam is installed via Flatpak

### DIFF
--- a/gameScanner.py
+++ b/gameScanner.py
@@ -120,6 +120,7 @@ def getMaybeGamePaths():
 	if common.Globals.IS_LINUX:
 		hardCodedGameContainingPaths.append("~/.steam/steam/steamapps/common/")
 		hardCodedGameContainingPaths.append("~/.steam/steambeta/steamapps/common/")
+		hardCodedGameContainingPaths.append("~/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/common") # Steam Flatpak
 		hardCodedGameContainingPaths.append("~/GOG Games")  # GOG's website states this, but is unconfirmed
 
 	for hardCodedPathNotNormalized in hardCodedGameContainingPaths:


### PR DESCRIPTION
Users of the Flatpak version of Steam should no longer have to select the game directory manually.