### PR TITLE
Use bundled cert for URLOpen

### DIFF
--- a/main.py
+++ b/main.py
@@ -272,6 +272,7 @@ if __name__ == "__main__":
 			common.Globals.scanForExecutables()
 			common.Globals.scanCertLocation()
 			common.Globals.chooseCurlCertificate()
+			common.Globals.chooseURLOpenCertificate()
 
 			# Run remaining init tasks concurrently
 			t_getSubModConfig = common.makeThread(thread_getSubModConfigList)


### PR DESCRIPTION
## Problem

Currently we bundle a certificate with the installer, used if no working certificate could be found for CURL. Curl is also only used as a fallback if urlopen doesn't work.

However, urlopen (python's builting fn that we use primarily) doesn't do the same check.

We recently had some MacOS reports where urlopen failed (due to not having cert available), but CURL would work initially. But later on in the installer, CURL would fail with exit status 8:

`subprocess.CalledProcessError: Command '['curl', '-fILX', 'GET', 'https://07th-mod.com/rikachama/graphics/Minagoroshi-Graphics.7z']' returned non-zero exit status 8.`

The solution was to run a command file that is bundled with Python to install certs (to make python use the builtin MacOS certs), as described here https://stackoverflow.com/questions/52805115/certificate-verify-failed-unable-to-get-local-issuer-certificate/62374703#62374703 which I put on the wiki.

However, we can just tell urlopen to use the bundled certificate, so the end user doesn't need to do anything.

## Solution

This PR looks for a working certificate for `urlopen`. Then it uses that cert when urlopen is called. It's basically a copy of the CURL certificate selection code.

The 'chosen' certificate is not shared between urlopen and CURL, just in case it somehow messes something up.

I wrote this up just now, but need to make sure I don't break anything.

## Note

Note: the cert is downloaded from here: https://curl.se/docs/caextract.html each time the installer is built.